### PR TITLE
fix: Reset player score to zero on death

### DIFF
--- a/server.js
+++ b/server.js
@@ -124,6 +124,7 @@ function killAndRespawn(pid) {
   const p = players.get(pid);
   if (!p || !p.alive) return;
   p.alive = false;
+  p.score = 0; // <<< ADD THIS LINE
   broadcastState(); // vanish immediately
 
   setTimeout(() => {


### PR DESCRIPTION
Updates the scoring system so that your player's score is reset to 0 when their blob is killed. This change occurs in the `killAndRespawn` function.