### PR TITLE
feat: Implement player-colored bullets

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -182,8 +182,9 @@ socket.addEventListener('message', ev => {
       gameArea.appendChild(el);
       bullets[b.id] = el;
     }
-    el.style.left = `${b.x - 5}px`;
-    el.style.top  = `${b.y - 5}px`;
+    el.style.left = `${b.x - 5}px`; // Assuming bullet radius is 5
+    el.style.top  = `${b.y - 5}px`; // Assuming bullet radius is 5
+    el.style.backgroundColor = b.color; // Apply color from server
   });
   // remove old bullets
   Object.keys(bullets).forEach(id => {

--- a/public/style.css
+++ b/public/style.css
@@ -41,7 +41,7 @@ html, body {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: black;
+  /* background: black; /* Default removed, JS sets color from server */
   pointer-events: none;
 }
 

--- a/server.js
+++ b/server.js
@@ -38,7 +38,7 @@ const COLORS = [
 // ——————— STORAGE ———————
 const players        = new Map();  // id → { ws, position, size, speed, alive, colour }
 const pendingClients = new Map();  // ws → id
-let bullets          = [];         // { id, shooterId, x, y, dx, dy, createdAt }
+let bullets          = [];         // { id, shooterId, x, y, dx, dy, createdAt, color } // Added color
 let nextBulletId     = 1;
 
 // Clamp a position so a blob of given size stays fully within the world
@@ -83,7 +83,8 @@ function broadcastState() {
   const bulletSnap = bullets.map(b => ({
     id: b.id,
     x:  b.x,
-    y:  b.y
+    y:  b.y,
+    color: b.color // <<< ADDED THIS LINE for broadcasting bullet color
   }));
 
   const msg = JSON.stringify({
@@ -199,7 +200,8 @@ wss.on('connection', ws => {
           y:         me.position.y,
           dx:        dx / mag,
           dy:        dy / mag,
-          createdAt: Date.now()
+          createdAt: Date.now(),
+          color:     me.colour // <<< ADDED THIS LINE to store shooter's color
         });
       }
     }


### PR DESCRIPTION
Bullets now visually match the color of the player who fired them.

Key changes:
- Server-Side (`server.js`):
  - When a bullet is created, the shooter's color (`me.colour`) is now stored as a `color` property on the bullet object.
  - The `broadcastState` function now includes this `color` property in the bullet data (`bulletSnap`) sent to clients.
- Client-Side (`public/client.js`):
  - The client now reads the `color` property from the bullet data received from the server.
  - This color is used to set the `backgroundColor` style of the bullet's DOM element, ensuring it matches the shooter's color.
- CSS (`public/style.css`):
  - Removed the default `background: black;` from the `.bullet` class, as the color is now dynamically set by JavaScript.

This enhancement provides better visual feedback, making it easier to identify the origin of bullets.